### PR TITLE
Handle leading (URL encoded) spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+
+.ruby-version
+.ruby-gemset

--- a/lib/salesforce_id_formatter.rb
+++ b/lib/salesforce_id_formatter.rb
@@ -2,10 +2,12 @@ require "salesforce_id_formatter/version"
 
 module SalesforceIdFormatter
   extend self
+  ENCODED_SPACE = '%20'
 
   InvalidId = Class.new(StandardError)
 
   def to_18(id)
+    id = remove_encoded_space(id) if has_encoded_space?(id)
     raise InvalidId unless valid_id?(id)
 
     id.size == 15 ? convert_15_to_18(id) : id
@@ -50,5 +52,13 @@ module SalesforceIdFormatter
     ]
     checkdigits = checkdigits.map {|d| decimal_to_base_32(d) }.join
     str + checkdigits
+  end
+
+  def remove_encoded_space(id)
+    id.sub ENCODED_SPACE, ''
+  end
+
+  def has_encoded_space?(id)
+    id.start_with? ENCODED_SPACE
   end
 end

--- a/test/test_salesforce_id_formatter.rb
+++ b/test/test_salesforce_id_formatter.rb
@@ -4,6 +4,8 @@ class TestSalesforceIdFormatter < Minitest::Test
   def test_to_18
     assert_equal valid_18_chars, SalesforceIdFormatter.to_18(valid_18_chars)
     assert_equal valid_18_chars, SalesforceIdFormatter.to_18(valid_15_chars)
+    assert_equal valid_18_chars, SalesforceIdFormatter.to_18(with_encoded_space_15)
+    assert_equal valid_18_chars, SalesforceIdFormatter.to_18(with_encoded_space_18)
 
     assert_raises SalesforceIdFormatter::InvalidId do
       SalesforceIdFormatter.to_18(too_short)
@@ -63,5 +65,13 @@ class TestSalesforceIdFormatter < Minitest::Test
 
   def invalid_chars
     '15InvalidChars!'
+  end
+
+  def with_encoded_space_15
+    '%2070130000001tcyI'
+  end
+
+  def with_encoded_space_18
+    '%2070130000001tcyIAAQ'
   end
 end


### PR DESCRIPTION
@raul  I'm not sure I like the implementation I chose, but this should strip out the encoded spaces at the start of the ID string. Thoughts?
